### PR TITLE
Extract mutation layer out of BufferLayer

### DIFF
--- a/spec/buffer-layer-spec.coffee
+++ b/spec/buffer-layer-spec.coffee
@@ -24,15 +24,6 @@ describe "BufferLayer", ->
       expect(buffer.slice()).toBe "abcdefghijkl"
       expect(source.getRecordedReads()).toEqual ["abc", "def", "ghi", "jkl", undefined]
 
-  describe "::splice(start, extent, content)", ->
-    it "replaces the extent at the given position with the given content", ->
-      source = new SpyLayer("abcdefghijkl", 3)
-      buffer = new BufferLayer(source)
-
-      buffer.splice(Point(0, 2), Point(0, 3), "123")
-
-      expect(buffer.slice()).toBe "ab123fghijkl"
-
   describe "iteration", ->
     it "returns an iterator into the buffer", ->
       source = new SpyLayer("abcdefghijkl", 3)
@@ -83,34 +74,3 @@ describe "BufferLayer", ->
 
       expect(buffer.slice(Point(0, 0), Point(0, 6))).toBe "abcdef"
       expect(source.getRecordedReads()).toEqual ["abc"]
-
-  describe "randomized mutations", ->
-    it "behaves as if it were reading and writing directly to the underlying layer", ->
-      for i in [0..30] by 1
-        seed = Date.now()
-        # seed = 1426552034823
-        random = new Random(seed)
-
-        oldContent = "abcdefghijklmnopqrstuvwxyz"
-        source = new StringLayer(oldContent)
-        buffer = new BufferLayer(source)
-        reference = new StringLayer(oldContent)
-
-        for j in [0..10] by 1
-          currentContent = buffer.slice()
-          newContentLength = random(20)
-          newContent = (oldContent[random(26)] for k in [0..newContentLength]).join("").toUpperCase()
-
-          startColumn = random(currentContent.length)
-          endColumn = random.intBetween(startColumn, currentContent.length)
-          start = Point(0, startColumn)
-          extent = Point(0, endColumn - startColumn)
-
-          # console.log buffer.slice()
-          # console.log "buffer.splice(#{start}, #{extent}, #{newContent})"
-
-          reference.splice(start, extent, newContent)
-          buffer.splice(start, extent, newContent)
-
-          expect(buffer.slice()).toBe(reference.slice(), "Seed: #{seed}, Iteration: #{j}")
-          return unless buffer.slice() is reference.slice()

--- a/spec/mutation-layer-spec.coffee
+++ b/spec/mutation-layer-spec.coffee
@@ -1,0 +1,123 @@
+Point = require "../src/point"
+StringLayer = require "../src/string-layer"
+MutationLayer = require "../src/mutation-layer"
+SpyLayer = require "./spy-layer"
+Random = require "random-seed"
+
+describe "MutationLayer", ->
+  describe "::slice(start, end)", ->
+    it "returns the content between the given start and end positions", ->
+      source = new SpyLayer("abcdefghijkl", 3)
+      mutationBuffer = new MutationLayer(source)
+      mutationBuffer.splice(Point(0, 0), Point(0, 3), "123")
+
+      expect(mutationBuffer.slice(Point(0, 1), Point(0, 3))).toBe "23"
+      expect(source.getRecordedReads()).toEqual ["def"]
+      source.reset()
+
+      expect(mutationBuffer.slice(Point(0, 2), Point(0, 8))).toBe "3defgh"
+      expect(source.getRecordedReads()).toEqual ["def", "ghi"]
+
+    it "returns the entire input text when no bounds are given", ->
+      source = new SpyLayer("abcdefghijkl", 3)
+      mutationBuffer = new MutationLayer(source)
+      mutationBuffer.splice(Point(0, 0), Point(0, 3), "123")
+
+      expect(mutationBuffer.slice()).toBe "123defghijkl"
+      expect(source.getRecordedReads()).toEqual ["def", "ghi", "jkl", undefined]
+
+  describe "::splice(start, extent, content)", ->
+    it "replaces the extent at the given position with the given content", ->
+      source = new SpyLayer("abcdefghijkl", 3)
+      mutationBuffer = new MutationLayer(source)
+
+      mutationBuffer.splice(Point(0, 2), Point(0, 3), "123")
+
+      expect(mutationBuffer.slice()).toBe "ab123fghijkl"
+
+  describe "iteration", ->
+    describe "when part of the content was spliced", ->
+      it "iterates the spliced content first, falling back to source layer", ->
+        source = new SpyLayer("abcdefghijkl", 3)
+        mutationBuffer = new MutationLayer(source)
+        mutationBuffer.splice(Point(0, 3), Point(0, 3), "123")
+        mutationBuffer.splice(Point(0, 7), Point(0, 3), "456")
+        iterator = mutationBuffer.buildIterator()
+        iterator.seek(Point(0, 3))
+
+        expect(iterator.next()).toEqual(value:"123", done: false)
+        expect(iterator.getPosition()).toEqual(Point(0, 6))
+
+        expect(iterator.next()).toEqual(value:"g", done: false)
+        expect(iterator.getPosition()).toEqual(Point(0, 7))
+
+        expect(iterator.next()).toEqual(value:"456", done: false)
+        expect(iterator.getPosition()).toEqual(Point(0, 10))
+
+        expect(iterator.next()).toEqual(value:"kl", done: false)
+        expect(iterator.getPosition()).toEqual(Point(0, 12))
+
+        expect(iterator.next()).toEqual(value: undefined, done: true)
+        expect(iterator.getPosition()).toEqual(Point(0, 12))
+
+        expect(source.getRecordedReads()).toEqual ["ghi", "kl", undefined]
+        source.reset()
+
+        iterator.seek(Point(0, 5))
+        expect(iterator.next()).toEqual(value:"3", done: false)
+
+    describe "when no content was spliced", ->
+      it "iterates transparently over the source layer", ->
+        source = new SpyLayer("abcdefghijkl", 3)
+        mutationBuffer = new MutationLayer(source)
+        iterator = mutationBuffer.buildIterator()
+        iterator.seek(Point(0, 3))
+
+        expect(iterator.next()).toEqual(value:"def", done: false)
+        expect(iterator.getPosition()).toEqual(Point(0, 6))
+
+        expect(iterator.next()).toEqual(value:"ghi", done: false)
+        expect(iterator.getPosition()).toEqual(Point(0, 9))
+
+        expect(iterator.next()).toEqual(value:"jkl", done: false)
+        expect(iterator.getPosition()).toEqual(Point(0, 12))
+
+        expect(iterator.next()).toEqual(value: undefined, done: true)
+        expect(iterator.getPosition()).toEqual(Point(0, 12))
+
+        expect(source.getRecordedReads()).toEqual ["def", "ghi", "jkl", undefined]
+        source.reset()
+
+        iterator.seek(Point(0, 5))
+        expect(iterator.next()).toEqual(value:"fgh", done: false)
+
+  describe "randomized mutations", ->
+    it "behaves as if it were reading and writing directly to the underlying layer", ->
+      for i in [0..30] by 1
+        seed = Date.now()
+        # seed = 1426552034823
+        random = new Random(seed)
+
+        oldContent = "abcdefghijklmnopqrstuvwxyz"
+        source = new StringLayer(oldContent)
+        mutationBuffer = new MutationLayer(source)
+        reference = new StringLayer(oldContent)
+
+        for j in [0..10] by 1
+          currentContent = mutationBuffer.slice()
+          newContentLength = random(20)
+          newContent = (oldContent[random(26)] for k in [0..newContentLength]).join("").toUpperCase()
+
+          startColumn = random(currentContent.length)
+          endColumn = random.intBetween(startColumn, currentContent.length)
+          start = Point(0, startColumn)
+          extent = Point(0, endColumn - startColumn)
+
+          # console.log mutationBuffer.slice()
+          # console.log "mutationBuffer.splice(#{start}, #{extent}, #{newContent})"
+
+          reference.splice(start, extent, newContent)
+          mutationBuffer.splice(start, extent, newContent)
+
+          expect(mutationBuffer.slice()).toBe(reference.slice(), "Seed: #{seed}, Iteration: #{j}")
+          return unless mutationBuffer.slice() is reference.slice()

--- a/src/buffer-layer.coffee
+++ b/src/buffer-layer.coffee
@@ -64,7 +64,3 @@ class Iterator
 
   getPosition: ->
     @position.copy()
-
-  splice: (extent, content) ->
-    @regionMapIterator.seek(@position)
-    @regionMapIterator.splice(extent, content)

--- a/src/mutation-layer.coffee
+++ b/src/mutation-layer.coffee
@@ -1,0 +1,54 @@
+Patch = require "./patch"
+Layer = require "./layer"
+Point = require "./point"
+
+module.exports =
+class MutationLayer extends Layer
+  constructor: (@source) ->
+    super
+    @mutatedContent = new Patch
+
+  buildIterator: ->
+    new Iterator(this, @source.buildIterator(), @mutatedContent.buildIterator())
+
+class Iterator
+  constructor: (@layer, @sourceIterator, @mutatedContentIterator) ->
+    @position = Point.zero()
+    @sourcePosition = Point.zero()
+
+  next: ->
+    comparison = @mutatedContentIterator.getPosition().compare(@position)
+    if comparison <= 0
+      @mutatedContentIterator.seek(@position) if comparison < 0
+      next = @mutatedContentIterator.next()
+      if next.value?
+        @position = @mutatedContentIterator.getPosition()
+        @sourcePosition = @mutatedContentIterator.getSourcePosition()
+        return {value: next.value, done: next.done}
+
+    @sourceIterator.seek(@sourcePosition)
+    next = @sourceIterator.next()
+    nextSourcePosition = @sourceIterator.getPosition()
+
+    sourceOvershoot = @sourceIterator.getPosition().traversalFrom(@mutatedContentIterator.getSourcePosition())
+    if sourceOvershoot.compare(Point.zero()) > 0
+      next.value = next.value.substring(0, next.value.length - sourceOvershoot.column)
+      nextPosition = @mutatedContentIterator.getPosition()
+    else
+      nextPosition = @position.traverse(nextSourcePosition.traversalFrom(@sourcePosition))
+
+    @sourcePosition = nextSourcePosition
+    @position = nextPosition
+    next
+
+  seek: (@position) ->
+    @mutatedContentIterator.seek(@position)
+    @sourcePosition = @mutatedContentIterator.getSourcePosition()
+    @sourceIterator.seek(@sourcePosition)
+
+  getPosition: ->
+    @position.copy()
+
+  splice: (extent, content) ->
+    @mutatedContentIterator.seek(@position)
+    @mutatedContentIterator.splice(extent, content)

--- a/src/text-document.coffee
+++ b/src/text-document.coffee
@@ -1,6 +1,7 @@
 fs = require "fs"
 Point = require "./point"
 BufferLayer = require "./buffer-layer"
+MutationLayer = require "./mutation-layer"
 StringLayer = require "./string-layer"
 LinesTransform = require "./lines-transform"
 TransformLayer = require "./transform-layer"
@@ -13,7 +14,7 @@ class TextDocument
 
   constructor: (options) ->
     @encoding = 'utf8'
-    @bufferLayer = new BufferLayer(new StringLayer(""))
+    @mutationLayer = new MutationLayer(new BufferLayer(new StringLayer("")))
     if typeof options is 'string'
       @setText(options)
     else if options?.filePath?
@@ -34,7 +35,7 @@ class TextDocument
     @getLinesLayer().slice()
 
   setText: (text) ->
-    @bufferLayer.splice(Point.zero(), @bufferLayer.getExtent(), text)
+    @mutationLayer.splice(Point.zero(), @mutationLayer.getExtent(), text)
 
   isModified: ->
     false
@@ -63,4 +64,4 @@ class TextDocument
     @getLinesLayer().toSourcePosition(Point.fromObject(position)).column
 
   getLinesLayer: ->
-    @linesLayer ?= new TransformLayer(@bufferLayer, new LinesTransform)
+    @linesLayer ?= new TransformLayer(@mutationLayer, new LinesTransform)


### PR DESCRIPTION
In this PR I basically moved `splice` from `BufferLayer` to `MutationLayer` (including its related specs). This new layer now correctly stores a patch when `splice` is called.

I'd like to point out the evident duplication between `BufferLayer` and `MutationLayer`: it seems like some code wants to be extracted there :art:. Since we're still fleshing out the basics, though, I might be speculating a bit over the design and, as a result, I didn't perform any refactoring. However, here's an idea to keep in mind. Basically, we may have a `CombinedIterator` which stores two (or even many) iterators with a priority, falling back to the next one when the current hasn't any available content. This would make really evident what `BufferLayer`'s and `MutationLayer`'s responsibilities are (that iteration code hides a bit the intent of those layers).

By the way, in order to complete this layer as described in our README specification, we still need to handle document saving. Since there are a few things which I am not sure of, I'll open a separate PR against this branch to implement it.

/cc: @nathansobo @maxbrunsfeld 
