### PR TITLE
Add TextBuffer APIs needed for rendering files in Atom

### DIFF
--- a/spec/text-document-spec.coffee
+++ b/spec/text-document-spec.coffee
@@ -1,5 +1,6 @@
 fs = require "fs"
 Point = require "../src/point"
+Range = require "../src/range"
 TextDocument = require "../src/text-document"
 
 describe "TextDocument", ->
@@ -48,10 +49,10 @@ describe "TextDocument", ->
       describe "when a file exists for the path", ->
         it "loads the contents of that file", (done) ->
           filePath = require.resolve('./fixtures/sample.js')
-          document = new TextDocument({filePath, load: true})
+          document = new TextDocument({filePath})
 
           expect(document.loaded).toBe false
-          document.onDidLoad ->
+          document.load().then ->
             expect(document.getText()).toBe fs.readFileSync(filePath, 'utf8')
             done()
 
@@ -59,66 +60,197 @@ describe "TextDocument", ->
         it "is not modified and is initially empty", (done) ->
           filePath = "does-not-exist.txt"
           expect(fs.existsSync(filePath)).toBeFalsy()
-          document = new TextDocument({filePath, load: true})
-          document.onDidLoad ->
+          document = new TextDocument({filePath})
+          document.load().then ->
             expect(document.isModified()).not.toBeTruthy()
             expect(document.getText()).toBe ''
             done()
 
-  describe "::clipPosition(position)", ->
-    it "returns a valid position closest to the given position", ->
-      document = new TextDocument
-      document.setText("hello\nworld\nhow are you doing?")
+  describe "lifecycle", ->
+    it "starts out with a reference count of 1", ->
+      destroyCallback = jasmine.createSpy("destroyCallback")
+      document.onDidDestroy(destroyCallback)
 
-      expect(document.clipPosition([-1, -1])).toEqual Point(0, 0)
-      expect(document.clipPosition([-1, 2])).toEqual Point(0, 0)
-      expect(document.clipPosition([0, -1])).toEqual Point(0, 0)
-      expect(document.clipPosition([0, 20])).toEqual Point(0, 5)
-      expect(document.clipPosition([1, -1])).toEqual Point(1, 0)
-      expect(document.clipPosition([1, 20])).toEqual Point(1, 5)
-      expect(document.clipPosition([10, 0])).toEqual Point(2, 18)
-      expect(document.clipPosition([Infinity, 0])).toEqual Point(2, 18)
+      document.retain()
+      document.release()
+      expect(destroyCallback).not.toHaveBeenCalled()
+      expect(document.isAlive()).toBe true
+      expect(document.isDestroyed()).toBe false
 
-  describe "::characterIndexForPosition(position)", ->
-    beforeEach ->
-      document = new TextDocument
-      document.setText("zero\none\r\ntwo\nthree")
+      document.retain()
+      document.retain()
+      document.release()
+      document.release()
+      expect(destroyCallback).not.toHaveBeenCalled()
+      expect(document.isAlive()).toBe true
+      expect(document.isDestroyed()).toBe false
 
-    it "returns the absolute character offset for the given position", ->
-      expect(document.characterIndexForPosition([0, 0])).toBe 0
-      expect(document.characterIndexForPosition([0, 1])).toBe 1
-      expect(document.characterIndexForPosition([0, 4])).toBe 4
-      expect(document.characterIndexForPosition([1, 0])).toBe 5
-      expect(document.characterIndexForPosition([1, 1])).toBe 6
-      expect(document.characterIndexForPosition([1, 3])).toBe 8
-      expect(document.characterIndexForPosition([2, 0])).toBe 10
-      expect(document.characterIndexForPosition([2, 1])).toBe 11
-      expect(document.characterIndexForPosition([3, 0])).toBe 14
-      expect(document.characterIndexForPosition([3, 5])).toBe 19
+      document.release()
+      expect(destroyCallback).toHaveBeenCalled()
+      expect(document.isAlive()).toBe false
+      expect(document.isDestroyed()).toBe true
 
-    it "clips the given position before translating", ->
-      expect(document.characterIndexForPosition([-1, -1])).toBe 0
-      expect(document.characterIndexForPosition([1, 100])).toBe 8
-      expect(document.characterIndexForPosition([100, 100])).toBe 19
+  describe "position translation", ->
+    describe "::clipPosition(position)", ->
+      it "returns a valid position closest to the given position", ->
+        document = new TextDocument
+        document.setText("hello\nworld\nhow are you doing?")
 
-  describe "::positionForCharacterIndex(offset)", ->
-    beforeEach ->
-      document = new TextDocument
-      document.setText("zero\none\r\ntwo\nthree")
+        expect(document.clipPosition([-1, -1])).toEqual Point(0, 0)
+        expect(document.clipPosition([-1, 2])).toEqual Point(0, 0)
+        expect(document.clipPosition([0, -1])).toEqual Point(0, 0)
+        expect(document.clipPosition([0, 20])).toEqual Point(0, 5)
+        expect(document.clipPosition([1, -1])).toEqual Point(1, 0)
+        expect(document.clipPosition([1, 20])).toEqual Point(1, 5)
+        expect(document.clipPosition([10, 0])).toEqual Point(2, 18)
+        expect(document.clipPosition([Infinity, 0])).toEqual Point(2, 18)
 
-    it "returns the position for the given absolute character offset", ->
-      expect(document.positionForCharacterIndex(0)).toEqual Point(0, 0)
-      expect(document.positionForCharacterIndex(1)).toEqual Point(0, 1)
-      expect(document.positionForCharacterIndex(4)).toEqual Point(0, 4)
-      expect(document.positionForCharacterIndex(5)).toEqual Point(1, 0)
-      expect(document.positionForCharacterIndex(6)).toEqual Point(1, 1)
-      expect(document.positionForCharacterIndex(8)).toEqual Point(1, 3)
-      expect(document.positionForCharacterIndex(9)).toEqual Point(1, 3)
-      expect(document.positionForCharacterIndex(10)).toEqual Point(2, 0)
-      expect(document.positionForCharacterIndex(11)).toEqual Point(2, 1)
-      expect(document.positionForCharacterIndex(14)).toEqual Point(3, 0)
-      expect(document.positionForCharacterIndex(19)).toEqual Point(3, 5)
+    describe "::characterIndexForPosition(position)", ->
+      beforeEach ->
+        document = new TextDocument
+        document.setText("zero\none\r\ntwo\nthree")
 
-    it "clips the given offset before translating", ->
-      expect(document.positionForCharacterIndex(-1)).toEqual Point(0, 0)
-      expect(document.positionForCharacterIndex(20)).toEqual Point(3, 5)
+      it "returns the absolute character offset for the given position", ->
+        expect(document.characterIndexForPosition([0, 0])).toBe 0
+        expect(document.characterIndexForPosition([0, 1])).toBe 1
+        expect(document.characterIndexForPosition([0, 4])).toBe 4
+        expect(document.characterIndexForPosition([1, 0])).toBe 5
+        expect(document.characterIndexForPosition([1, 1])).toBe 6
+        expect(document.characterIndexForPosition([1, 3])).toBe 8
+        expect(document.characterIndexForPosition([2, 0])).toBe 10
+        expect(document.characterIndexForPosition([2, 1])).toBe 11
+        expect(document.characterIndexForPosition([3, 0])).toBe 14
+        expect(document.characterIndexForPosition([3, 5])).toBe 19
+
+      it "clips the given position before translating", ->
+        expect(document.characterIndexForPosition([-1, -1])).toBe 0
+        expect(document.characterIndexForPosition([1, 100])).toBe 8
+        expect(document.characterIndexForPosition([100, 100])).toBe 19
+
+    describe "::positionForCharacterIndex(offset)", ->
+      beforeEach ->
+        document = new TextDocument
+        document.setText("zero\none\r\ntwo\nthree")
+
+      it "returns the position for the given absolute character offset", ->
+        expect(document.positionForCharacterIndex(0)).toEqual Point(0, 0)
+        expect(document.positionForCharacterIndex(1)).toEqual Point(0, 1)
+        expect(document.positionForCharacterIndex(4)).toEqual Point(0, 4)
+        expect(document.positionForCharacterIndex(5)).toEqual Point(1, 0)
+        expect(document.positionForCharacterIndex(6)).toEqual Point(1, 1)
+        expect(document.positionForCharacterIndex(8)).toEqual Point(1, 3)
+        expect(document.positionForCharacterIndex(9)).toEqual Point(1, 3)
+        expect(document.positionForCharacterIndex(10)).toEqual Point(2, 0)
+        expect(document.positionForCharacterIndex(11)).toEqual Point(2, 1)
+        expect(document.positionForCharacterIndex(14)).toEqual Point(3, 0)
+        expect(document.positionForCharacterIndex(19)).toEqual Point(3, 5)
+
+      it "clips the given offset before translating", ->
+        expect(document.positionForCharacterIndex(-1)).toEqual Point(0, 0)
+        expect(document.positionForCharacterIndex(20)).toEqual Point(3, 5)
+
+  describe "markers", ->
+    describe "::markPosition", ->
+      it "returns a marker for the given position with the given properties", ->
+        marker = document.markPosition([0, 6], a: '1')
+        expect(marker.getRange()).toEqual Range(Point(0, 6), Point(0, 6))
+        expect(marker.getHeadPosition()).toEqual Point(0, 6)
+        expect(marker.getTailPosition()).toEqual Point(0, 6)
+        expect(marker.getProperties()).toEqual {a: '1'}
+
+        expect(marker.matchesParams({})).toBe true
+        expect(marker.matchesParams(a: '1')).toBe true
+        expect(marker.matchesParams(a: '2')).toBe false
+
+      it "allows the marker to be retrieved with ::findMarkers(properties)", ->
+        marker1 = document.markPosition([0, 6], a: '1', b: '2')
+        marker2 = document.markPosition([0, 6], a: '1', b: '3')
+        marker3 = document.markPosition([0, 6], a: '2', )
+
+        expect(document.findMarkers(a: '1')).toEqual([marker1, marker2])
+
+      it "allows the marker to be retrieved with ::getMarker(id)", ->
+        marker1 = document.markPosition([0, 6], a: '1', b: '2')
+        marker2 = document.markPosition([0, 6], a: '1', b: '3')
+        marker3 = document.markPosition([0, 6], a: '2', )
+
+        expect(document.getMarker(marker1.id)).toBe marker1
+        expect(document.getMarker(marker2.id)).toBe marker2
+        expect(document.getMarker(marker3.id)).toBe marker3
+        expect(document.getMarker(1234)).toBeUndefined()
+
+      it "calls callbacks registered with ::onDidCreateMarker(fn)", ->
+        createdMarkers = []
+        document.onDidCreateMarker (marker) ->
+          expect(marker).toBe document.getMarker(marker.id)
+          createdMarkers.push(marker)
+
+        marker = document.markPosition([0, 6])
+        expect(createdMarkers).toEqual([marker])
+
+    describe "Marker::setProperties", ->
+      it "allows the properties to be retrieved", ->
+        marker = document.markPosition([0, 6], a: '1')
+        marker.setProperties(b: '2')
+
+        expect(marker.getProperties()).toEqual(a: '1', b: '2')
+        expect(document.findMarkers(b: '2')).toEqual [marker]
+
+  describe "manipulating text", ->
+    describe "::isEmpty", ->
+      it "returns true if the document has no text", ->
+        expect(document.isEmpty()).toBe true
+        document.setText("a")
+        expect(document.isEmpty()).toBe false
+
+    describe "::getTextInRange(range)", ->
+      it "returns the text between the range's start and end positions", ->
+        document.setText """
+          one
+          two
+          three
+          four
+        """
+
+        expect(document.getTextInRange([[1, 2], [2, 4]])).toBe """
+          o
+          thre
+        """
+
+    describe "::setTextInRange(range, text)", ->
+      it "replaces the text in the given range with the given text", ->
+        changeEvents = []
+        document.onDidChange (event) -> changeEvents.push(event)
+
+        document.setText """
+          one
+          two
+          three
+          four
+        """
+
+        newRange = document.setTextInRange([[1, 2], [2, 4]], "inkl")
+        expect(document.getText()).toBe """
+          one
+          twinkle
+          four
+        """
+
+        expect(newRange).toEqual(Range(Point(1, 2), Point(1, 6)))
+        expect(changeEvents).toEqual([{
+          oldText: "o\nthre"
+          newText: "inkl"
+          oldRange: Range(Point(1, 2), Point(2, 4))
+          newRange: Range(Point(1, 2), Point(1, 6))
+        }])
+
+      it "calls callbacks registered with ::onDidChange(fn)", ->
+
+  describe "file details", ->
+    describe "encoding", ->
+      it "uses utf8 by default", ->
+        expect(document.getEncoding()).toBe "utf8"
+
+      it "allows the encoding to be set with ::setEncoding(encoding)", ->
+        document.setEncoding("ascii")
+        expect(document.getEncoding()).toBe "ascii"

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -1,0 +1,49 @@
+{Emitter} = require "event-kit"
+
+module.exports =
+class Marker
+  constructor: (@id, @range, @properties) ->
+    @emitter = new Emitter
+
+  getRange: -> @range
+
+  getHeadPosition: -> @range.start
+
+  getTailPosition: -> @range.end
+
+  setHeadPosition: ->
+
+  setTailPosition: ->
+
+  isValid: -> true
+
+  matchesParams: (params) ->
+    for key, value of params
+      return false unless @properties[key] is value
+    true
+
+  getProperties: -> @properties
+
+  setProperties: (newProperties) ->
+    for key, value of newProperties
+      @properties[key] = value
+
+  isReversed: -> false
+
+  hasTail: -> false
+
+  clearTail: ->
+
+  plantTail: ->
+
+  destroy: ->
+
+  ###
+  Section: Event Subscription
+  ###
+
+  onDidDestroy: (callback) ->
+    @emitter.on("did-destroy", callback)
+
+  onDidChange: (callback) ->
+    @emitter.on("did-change", callback)

--- a/src/range.coffee
+++ b/src/range.coffee
@@ -1,0 +1,25 @@
+Point = require "./point"
+
+module.exports =
+class Range
+  @fromObject: (object) ->
+    if object instanceof Range
+      object
+    else
+      if Array.isArray(object)
+        [start, end] = object
+      else
+        {start, end} = object
+      new Range(start, end)
+
+  constructor: (start, end) ->
+    unless this instanceof Range
+      return new Range(start, end)
+    @start = Point.fromObject(start)
+    @end = Point.fromObject(end)
+
+  isEqual: (other) ->
+    @start is other.start and @end is other.end
+
+  isEmpty: ->
+    @start.compare(@end) is 0

--- a/src/text-document.coffee
+++ b/src/text-document.coffee
@@ -1,6 +1,8 @@
 fs = require "fs"
 {Emitter} = require "event-kit"
 Point = require "./point"
+Range = require "./range"
+Marker = require "./marker"
 BufferLayer = require "./buffer-layer"
 StringLayer = require "./string-layer"
 LinesTransform = require "./lines-transform"
@@ -12,41 +14,144 @@ module.exports =
 class TextDocument
   linesLayer: null
 
+  ###
+  Section: Construction
+  ###
+
   constructor: (options) ->
+    @nextMarkerId = 0
+    @markers = []
     @emitter = new Emitter
+    @refcount = 1
+    @destroyed = false
     @encoding = 'utf8'
     @bufferLayer = new BufferLayer(new StringLayer(""))
     if typeof options is 'string'
       @setText(options)
     else if options?.filePath?
-      @setPath(options.filePath, options.load)
+      @setPath(options.filePath)
       @load() if options.load
 
+  ###
+  Section: Lifecycle
+  ###
+
   destroy: ->
+    @destroyed = true
+    @emitter.emit "did-destroy"
+
+  retain: ->
+    @refcount++
+
+  release: ->
+    @refcount--
+    @destroy() if @refcount is 0
+
+  isAlive: ->
+    not @destroyed
+
+  isDestroyed: ->
+    @destroyed
+
+  ###
+  Section: Event Subscription
+  ###
+
+  onDidChange: (callback) ->
+    @emitter.on("did-change", callback)
+
+  onDidDestroy: (callback) ->
+    @emitter.on("did-destroy", callback)
+
+  onWillThrowWatchError: (callback) ->
+    @emitter.on("will-throw-watch-error", callback)
+
+  onDidSave: (callback) ->
+    @emitter.on("did-save", callback)
+
+  onDidChangePath: (callback) ->
+    @emitter.on("did-change-path", callback)
+
+  preemptDidChange: (callback) ->
+    @emitter.preempt("did-change-path", callback)
+
+  onDidUpdateMarkers: (callback) ->
+    @emitter.on("did-update-markers", callback)
+
+  onDidCreateMarker: (callback) ->
+    @emitter.on("did-create-marker", callback)
+
+  onDidChangeEncoding: (callback) ->
+    @emitter.on("did-change-encoding", callback)
+
+  onDidStopChanging: (callback) ->
+    @emitter.on("did-stop-changing", callback)
+
+  onDidConflict: (callback) ->
+    @emitter.on("did-conflict", callback)
+
+  onDidChangeModified: (callback) ->
+    @emitter.on("did-change-modified", callback)
+
+  onWillReload: (callback) ->
+    @emitter.on("will-reload", callback)
+
+  onDidReload: (callback) ->
+    @emitter.on("did-reload", callback)
+
+  onWillSave: (callback) ->
+    @emitter.on("will-save", callback)
+
+  ###
+  Section: File Details
+  ###
+
+  getPath: -> @path
+
+  getUri: -> @path
 
   setPath: (@path) ->
     @loaded = false
 
   load: ->
-    fs.readFile @path, @encoding, (err, contents) =>
-      @loaded = true
-      @setText(contents) if contents
-      @emitter.emit("did-load")
-
-  onDidLoad: (fn) ->
-    @emitter.on("did-load", fn)
-
-  getText: ->
-    @getLinesLayer().slice()
-
-  setText: (text) ->
-    @bufferLayer.splice(Point.zero(), @bufferLayer.getExtent(), text)
+    new Promise (resolve) =>
+      fs.readFile @path, @encoding, (err, contents) =>
+        @loaded = true
+        @setText(contents) if contents
+        @emitter.emit("did-load")
+        resolve()
 
   isModified: ->
     false
 
-  getLineCount: ->
-    @getLinesLayer().getExtent().row + 1
+  setEncoding: (@encoding) ->
+
+  getEncoding: -> @encoding
+
+  ###
+  Section: Reading Text
+  ###
+
+  getText: ->
+    @getLinesLayer().slice()
+
+  getTextInRange: (range) ->
+    range = Range.fromObject(range)
+    @getLinesLayer().slice(range.start, range.end)
+
+  setText: (text) ->
+    @bufferLayer.splice(Point.zero(), @bufferLayer.getExtent(), text)
+
+  setTextInRange: (oldRange, newText) ->
+    oldRange = Range.fromObject(oldRange)
+    linesLayer = @getLinesLayer()
+    oldText = @getTextInRange(oldRange)
+    start = linesLayer.toSourcePosition(oldRange.start)
+    end = linesLayer.toSourcePosition(oldRange.end)
+    @bufferLayer.splice(start, end.traversalFrom(start), newText)
+    newRange = new Range(oldRange.start, linesLayer.fromSourcePosition(start.traverse(Point(0, newText.length))))
+    @emitter.emit("did-change", {oldText, newText, oldRange, newRange})
+    newRange
 
   lineForRow: (row) ->
     @getLinesLayer()
@@ -58,6 +163,44 @@ class TextDocument
       .slice(Point(row, 0), Point(row + 1, 0))
       .match(LineEnding, "")[0]
 
+  isEmpty: ->
+    @bufferLayer.getExtent().isZero()
+
+  previousNonBlankRow: -> 0
+
+  nextNonBlankRow: -> 0
+
+  isRowBlank: -> false
+
+  ###
+  Section: Markers
+  ###
+
+  getMarker: (id) ->
+    return marker for marker in @markers when marker.id is id
+
+  getMarkers: ->
+    @markers
+
+  findMarkers: (params) ->
+    @markers.filter (marker) -> marker.matchesParams(params)
+
+  markPosition: (position, options) ->
+    marker = new Marker(@nextMarkerId++, new Range(Point.fromObject(position), Point.fromObject(position)), options)
+    @markers.push(marker)
+    @emitter.emit("did-create-marker", marker)
+    marker
+
+  ###
+  Section: Buffer Range Details
+  ###
+
+  getLineCount: ->
+    @getLinesLayer().getExtent().row + 1
+
+  getLastRow: ->
+    @getLineCount() - 1
+
   clipPosition: (position) ->
     position = Point.fromObject(position)
     @getLinesLayer().clipPosition(position)
@@ -67,6 +210,22 @@ class TextDocument
 
   characterIndexForPosition: (position) ->
     @getLinesLayer().toSourcePosition(Point.fromObject(position)).column
+
+  ###
+  Section: History
+  ###
+
+  transact: (groupingInterval, fn) ->
+    if typeof groupingInterval is 'function'
+      fn = groupingInterval
+      groupingInterval = 0
+    fn()
+
+  groupChangesSinceCheckpoint: ->
+
+  ###
+  Section: Private
+  ###
 
   getLinesLayer: ->
     @linesLayer ?= new TransformLayer(@bufferLayer, new LinesTransform)


### PR DESCRIPTION
TextEditors are able to render, without cursor movement or editing. I have [a branch](https://github.com/atom/atom/tree/mb-use-text-document) of Atom for testing this out.
- [x] Make `TextDocument` able to substitute for `TextBuffer` (with no editing support)
- [ ] Make `TextDisplayDocument` able to substitute for `DisplayBuffer` (with no editing support)

![screen shot 2015-03-26 at 7 35 58 pm](https://cloud.githubusercontent.com/assets/326587/6861198/6ec2855e-d3ef-11e4-8a04-8d14becd3c7d.png)
